### PR TITLE
Fix README typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ bash <(curl -sSL https://raw.githubusercontent.com/CX330Blake/ZYRA/main/install.
 > [!WARNING]  
 > Never execute any untrusted script on your machine. Read the script first.
 
-On the other hand, you can clone this repo and use the following command to build your own ZYRA biary.
+On the other hand, you can clone this repo and use the following command to build your own ZYRA binary.
 
 ```bash
 git clone https://github.com/CX330Blake/ZYRA


### PR DESCRIPTION
## Summary
- correct `biary` typo to `binary` in installation docs

## Testing
- `grep -n "binary" -n README.md | head`


------
https://chatgpt.com/codex/tasks/task_e_68402a6a9a1883208021f5a530ea7de9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Fixed a typographical error in the Installation section of the README.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->